### PR TITLE
fix: make label smoothing delta configurable

### DIFF
--- a/deepcase/__main__.py
+++ b/deepcase/__main__.py
@@ -200,6 +200,7 @@ if __name__ == "__main__":
             batch_size    = args.batch,
             learning_rate = 0.01,
             teach_ratio   = 0.5,
+            delta         = args.delta,
             verbose       = not args.silent,
         )
 

--- a/deepcase/context_builder/context_builder.py
+++ b/deepcase/context_builder/context_builder.py
@@ -196,7 +196,7 @@ class ContextBuilder(nn.Module):
     ########################################################################
 
     def fit(self, X, y, epochs=10, batch_size=128, learning_rate=0.01,
-            optimizer=optim.SGD, teach_ratio=0.5, verbose=True):
+            optimizer=optim.SGD, teach_ratio=0.5, delta=0.1, verbose=True):
         """Fit the sequence predictor with labelled data
 
             Parameters
@@ -222,6 +222,9 @@ class ContextBuilder(nn.Module):
             teach_ratio : float, default=0.5
                 Ratio of sequences to train including labels.
 
+            delta : float, default=0.1
+                Label smoothing factor to apply during training.
+
             verbose : boolean, default=True
                 If True, prints progress.
 
@@ -243,7 +246,7 @@ class ContextBuilder(nn.Module):
         self.train()
 
         # Set criterion and optimiser
-        criterion = LabelSmoothing(self.decoder_event.out.out_features, 0.1)
+        criterion = LabelSmoothing(self.decoder_event.out.out_features, delta)
         optimizer = optimizer(
             params = self.parameters(),
             lr     = learning_rate
@@ -356,7 +359,8 @@ class ContextBuilder(nn.Module):
 
 
     def fit_predict(self, X, y, epochs=10, batch_size=128, learning_rate=0.01,
-                    optimizer=optim.SGD, teach_ratio=0.5, verbose=True):
+                    optimizer=optim.SGD, teach_ratio=0.5, delta=0.1,
+                    verbose=True):
         """Fit the sequence predictor with labelled data
 
             Parameters
@@ -382,6 +386,9 @@ class ContextBuilder(nn.Module):
             teach_ratio : float, default=0.5
                 Ratio of sequences to train including labels
 
+            delta : float, default=0.1
+                Label smoothing factor to apply during training
+
             verbose : boolean, default=True
                 If True, prints progress
 
@@ -401,6 +408,7 @@ class ContextBuilder(nn.Module):
             learning_rate = learning_rate,
             optimizer     = optimizer,
             teach_ratio   = teach_ratio,
+            delta         = delta,
             verbose       = verbose,
         ).predict(X)
 

--- a/deepcase/module.py
+++ b/deepcase/module.py
@@ -90,6 +90,7 @@ class DeepCASE(object):
             learning_rate = 0.01,
             optimizer     = optim.SGD,
             teach_ratio   = 0.5,
+            delta         = 0.1,
 
             # Interpreter-specific parameters
             iterations       = 100,
@@ -132,6 +133,9 @@ class DeepCASE(object):
             teach_ratio : float, default=0.5
                 Ratio of sequences to train including labels.
 
+            delta : float, default=0.1
+                Label smoothing factor to apply during ContextBuilder training.
+
             iterations : int, default=100
                 Number of iterations for query.
 
@@ -169,6 +173,7 @@ class DeepCASE(object):
             learning_rate = learning_rate,
             optimizer     = optimizer,
             teach_ratio   = teach_ratio,
+            delta         = delta,
             verbose       = verbose,
         )
 
@@ -249,6 +254,7 @@ class DeepCASE(object):
             learning_rate = 0.01,
             optimizer     = optim.SGD,
             teach_ratio   = 0.5,
+            delta         = 0.1,
 
             # Interpreter-specific parameters
             iterations       = 100,
@@ -290,6 +296,9 @@ class DeepCASE(object):
 
             teach_ratio : float, default=0.5
                 Ratio of sequences to train including labels.
+
+            delta : float, default=0.1
+                Label smoothing factor to apply during ContextBuilder training.
 
             iterations : int, default=100
                 Number of iterations for query.
@@ -335,6 +344,7 @@ class DeepCASE(object):
             learning_rate    = learning_rate,
             optimizer        = optimizer,
             teach_ratio      = teach_ratio,
+            delta            = delta,
             iterations       = iterations,
             query_batch_size = query_batch_size,
             strategy         = strategy,

--- a/docs/source/usage/code.rst
+++ b/docs/source/usage/code.rst
@@ -106,6 +106,7 @@ Once the ``context_builder`` is created, we train it using the :py:meth:`fit()` 
         epochs        = 10,                          # Number of epochs to train with
         batch_size    = 128,                         # Number of samples in each training batch, in paper this was 128
         learning_rate = 0.01,                        # Learning rate to train with, in paper this was 0.01
+        delta         = 0.1,                         # Label smoothing factor
         verbose       = True,                        # If True, prints progress
     )
 


### PR DESCRIPTION
## Summary
Thread the label smoothing `delta` parameter through DeepCASE training so it is configurable instead of hardcoded.

## Changes
- pass CLI `--delta` into `ContextBuilder.fit`
- add `delta` to `ContextBuilder.fit_predict`
- expose `delta` on DeepCASE wrapper methods
- use the passed `delta` when constructing `LabelSmoothing`
- document `delta` in the usage example

## Why
Previously, `LabelSmoothing` always received a hardcoded value of `0.1`, even though a CLI `--delta` option already existed. This change makes training behaviour consistent with the exposed interface and allows callers to tune label smoothing explicitly.

## Notes
- default behaviour is unchanged: `delta` still defaults to `0.1`
- this is a plumbing/documentation change; no algorithmic behaviour changes unless a non-default `delta` is provided