### PR TITLE
Fix parameter forwarding in fit_predict and correct progress loss normalisation

### DIFF
--- a/deepcase/context_builder/context_builder.py
+++ b/deepcase/context_builder/context_builder.py
@@ -290,8 +290,8 @@ class ContextBuilder(nn.Module):
                     optimizer.step()
 
                     # Update description
-                    total_loss  += loss.item() / X_.shape[1]
-                    total_items += X_.shape[0]
+                    total_loss  += loss.item()
+                    total_items += X_.shape[0] * y_.shape[1]
 
                     if verbose:
                         data.set_description(

--- a/deepcase/interpreter/interpreter.py
+++ b/deepcase/interpreter/interpreter.py
@@ -333,9 +333,9 @@ class Interpreter(object):
         ).predict(
             X          = X,
             y          = y,
-            iterations = 100,
-            batch_size = 1024,
-            verbose    = False,
+            iterations = iterations,
+            batch_size = batch_size,
+            verbose    = verbose,
         )
 
     ########################################################################


### PR DESCRIPTION
This PR fixes two issues in inference configuration and training progress reporting.

### 1. Forward `fit_predict` parameters correctly

`Interpreter.fit_predict()` previously ignored caller-provided `iterations`, `batch_size`, and `verbose`, always using hardcoded defaults when calling `predict()`.

This PR forwards those arguments through so runtime behaviour matches the caller’s configuration.

---

### 2. Fix progress loss normalisation

Progress loss was previously accumulated as:

```python
total_loss += loss.item() / X_.shape[1]
total_items += X_.shape[0]
```

This mixes units: the loss is scaled per timestep (`X_.shape[1]`), but averaged per sequence (`X_.shape[0]`), which underestimates the true mean loss.

The update instead:

```python
total_loss  += loss.item()
total_items += X_.shape[0] * y_.shape[1]
```

i.e.

* accumulate the **total loss over all predictions**
* divide by the **total number of target elements** (`batch_size × sequence_length`)

This makes the reported loss a true per-prediction average.

This change affects **only the progress display**, not optimisation or model outputs.